### PR TITLE
Extend business types and questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # compatibility-app
-"Know Your Type! Team Compatibility App" - A business personality type assessment tool for corporate events. Categorizes participants into 4 business style types based on their answers. Features a mobile-optimized interface with swipe navigation.
+"Know Your Type! Team Compatibility App" - A business personality type assessment tool for corporate events. Categorizes participants into 6 business style types based on their answers. Features a mobile-optimized interface with swipe navigation.
+The questionnaire now contains eight questions.

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <div id="question-screen" class="screen">
             <div class="progress-bar">
                 <div class="progress-inner" style="width: 0%"></div>
-                <div class="progress-text">1/6</div>
+                <div class="progress-text">1/8</div>
             </div>
             
             <div class="card-container">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -124,6 +124,8 @@ function calculateResultType(answers) {
     leader: 0,
     supporter: 0,
     innovator: 0
+    coordinator: 0,
+    strategist: 0
   };
   
   // 各回答に応じてスコアを加算

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -9,17 +9,17 @@ const APP_CONFIG = {
   title: "知っトク相性チェック！",
   subtitle: "チーム診断",
   startButtonText: "診断スタート",
-  
+
   // 説明文
   description: "あなたのビジネスタイプを診断します",
-  
+
   // スワイプヒントの文言
   swipeHint: "カードを左右にスワイプして選択",
-  
+
   // 選択肢のラベル
   choiceALabel: "選択 A",
   choiceBLabel: "選択 B",
-  
+
   // 結果画面の設定
   resultTitle: "あなたのタイプは",
   resultInstruction: "＝＝＝",
@@ -60,6 +60,22 @@ const BUSINESS_TYPES = {
     description: '創造的で新しいアイデアを生み出すのが得意です。変化を恐れない柔軟性があります。',
     strengths: ['創造性', '柔軟性', '発想力'],
     gatheringSpot: '右後方'
+  },
+  COORDINATOR: {
+    id: 'coordinator',
+    name: 'コーディネーター型',
+    color: '#9C27B0', // 紫色
+    description: 'プロジェクト全体を調整し、チーム間の連携をスムーズにするのが得意です。',
+    strengths: ['調整力', 'コミュニケーション', '計画立案'],
+    gatheringSpot: '中央'
+  },
+  STRATEGIST: {
+    id: 'strategist',
+    name: 'ストラテジスト型',
+    color: '#009688', // ティール色
+    description: '長期的な視点で戦略を立て、最適な方向性を示します。',
+    strengths: ['戦略思考', '分析力', '計画力'],
+    gatheringSpot: 'ステージ前方'
   }
 };
 
@@ -100,21 +116,37 @@ const QUESTIONS = [
     question: '仕事の成果として、どちらをより重視しますか？',
     optionA: '正確さと完成度',
     optionB: '人間関係の構築と維持'
+  },
+  {
+    id: 7,
+    question: 'チームのモチベーションを保つために重視するのは？',
+    optionA: '目標に向けた具体的な計画',
+    optionB: 'メンバー同士の調整とサポート'
+  },
+  {
+    id: 8,
+    question: 'プロジェクトの方向性を決めるとき、どちらを優先しますか？',
+    optionA: '長期的な戦略',
+    optionB: '柔軟な対応力'
   }
 ];
 
 // スコア計算用のポイント配分
 const TYPE_SCORE_MAP = {
-  A1: { analyst: 2, leader: 0, supporter: 0, innovator: 1 },
-  B1: { analyst: 0, leader: 1, supporter: 2, innovator: 0 },
-  A2: { analyst: 1, leader: 2, supporter: 0, innovator: 0 },
-  B2: { analyst: 0, leader: 0, supporter: 1, innovator: 2 },
-  A3: { analyst: 1, leader: 0, supporter: 2, innovator: 0 },
-  B3: { analyst: 0, leader: 2, supporter: 0, innovator: 1 },
-  A4: { analyst: 0, leader: 0, supporter: 1, innovator: 2 },
-  B4: { analyst: 2, leader: 1, supporter: 0, innovator: 0 },
-  A5: { analyst: 0, leader: 2, supporter: 1, innovator: 0 },
-  B5: { analyst: 1, leader: 0, supporter: 0, innovator: 2 },
-  A6: { analyst: 2, leader: 1, supporter: 0, innovator: 0 },
-  B6: { analyst: 0, leader: 0, supporter: 2, innovator: 1 }
-}; 
+  A1: { analyst: 2, leader: 0, supporter: 0, innovator: 1, coordinator: 0, strategist: 0 },
+  B1: { analyst: 0, leader: 1, supporter: 2, innovator: 0, coordinator: 0, strategist: 0 },
+  A2: { analyst: 1, leader: 2, supporter: 0, innovator: 0, coordinator: 0, strategist: 0 },
+  B2: { analyst: 0, leader: 0, supporter: 1, innovator: 2, coordinator: 0, strategist: 0 },
+  A3: { analyst: 1, leader: 0, supporter: 2, innovator: 0, coordinator: 0, strategist: 0 },
+  B3: { analyst: 0, leader: 2, supporter: 0, innovator: 1, coordinator: 0, strategist: 0 },
+  A4: { analyst: 0, leader: 0, supporter: 1, innovator: 2, coordinator: 0, strategist: 0 },
+  B4: { analyst: 2, leader: 1, supporter: 0, innovator: 0, coordinator: 0, strategist: 0 },
+  A5: { analyst: 0, leader: 2, supporter: 1, innovator: 0, coordinator: 0, strategist: 0 },
+  B5: { analyst: 1, leader: 0, supporter: 0, innovator: 2, coordinator: 0, strategist: 0 },
+  A6: { analyst: 2, leader: 1, supporter: 0, innovator: 0, coordinator: 0, strategist: 0 },
+  B6: { analyst: 0, leader: 0, supporter: 2, innovator: 1, coordinator: 0, strategist: 0 },
+  A7: { analyst: 1, leader: 0, supporter: 0, innovator: 0, coordinator: 0, strategist: 2 },
+  B7: { analyst: 0, leader: 1, supporter: 1, innovator: 0, coordinator: 2, strategist: 0 },
+  A8: { analyst: 1, leader: 1, supporter: 0, innovator: 0, coordinator: 0, strategist: 2 },
+  B8: { analyst: 0, leader: 0, supporter: 1, innovator: 2, coordinator: 1, strategist: 0 }
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,6 +5,8 @@
   --color-supporter: #43A047;
   --color-innovator: #FFB300;
   --color-background: #f8f9fa;
+  --color-coordinator: #9C27B0;
+  --color-strategist: #009688;
   --color-text: #333;
   --color-accent: #2196F3;
   --color-option-a: #4CAF50; /* 選択肢A（左スワイプ）*/


### PR DESCRIPTION
## Summary
- support new Coordinator and Strategist types
- add color variables for new types
- append two more questions
- expand score mapping and result calculation
- update progress text for new question count
- document new total types and questions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686761a19fdc832985f77ea1a97bfa48